### PR TITLE
Removed types.h include because newer curl removes it and thus break comp

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -6,7 +6,6 @@
 #include <map>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 struct HTTPINFO


### PR DESCRIPTION
Removed types.h include because newer curl removes it and thus break compilation

The file has not been used for 10 years or so, thus removal is completely harmless.
