### PR TITLE
Remove unused NLS configuration

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -137,6 +137,7 @@ else:
         LINKFLAGS = ['-pthread'],
         CC = 'gcc', CXX = 'g++',
         options = opts)
+    env['LINKFLAGS'] += SCons.Util.CLVar(os.environ['LDFLAGS'])
     check_headers = ['asio.hpp', 'boost/bind.hpp', 'GL/gl.h', 'GL/glu.h', 'SDL/SDL.h', 'SDL/SDL_image.h', 'SDL/SDL_rotozoom.h', 'vorbis/vorbisfile.h', 'GL/glew.h', 'curl/curl.h', 'bullet/btBulletCollisionCommon.h', 'archive.h']
     check_libs = [ ['GLEW', 'GL/glew.h', 'glDeleteSamplers(0, NULL);', 'Your GLEW library is out of date.'] ]
 


### PR DESCRIPTION
As far as I can tell NLS configuration is unused, making it confusing for downstream packagers. Also, LDFLAGS should be respected.
