### PR TITLE
Update appdata to comply with new specification

### DIFF
--- a/vdrift.appdata.xml
+++ b/vdrift.appdata.xml
@@ -2,7 +2,8 @@
 <!-- Copyright 2014 Sergej Forat <core13@gmx.net> -->
 <application>
  <id type="desktop">vdrift.desktop</id>
- <licence>CC0</licence>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
  <name>VDrift</name>
  <summary>Car Racing Simulator</summary>
  <description>


### PR DESCRIPTION
http://blogs.gnome.org/hughsie/2014/05/02/appdata-meet-spdx-spdx-meet-appdata/

Please let me know if I messed up on the project licensing, I was unsure of the vdrift-data license, as the only thing I could find was that "vdrift" was gplv3. The fedora repo shows that "vdrift-data" is GPLv3+ so I went with that.
