### PR TITLE
Fixed .desktop and appdata file

### DIFF
--- a/vdrift.appdata.xml
+++ b/vdrift.appdata.xml
@@ -17,7 +17,6 @@
    VDrift aims to provide an accurate driving physics emulation, based on real world data of the actual vehicles, employing a full rigid body simulation and a complex tire model.
    The recommended input method is a steering wheel with pedals and force feedback support.
   </p>
-  </ul> 
  </description>
  <screenshots>
   <screenshot type="default" width="899" height="507">https://github.com/VDrift/vdrift/blob/master/vdrift/raw/2f19c79de4fac0c326fa099dba7d9f19362552d0/miura_vdrift_899.jpg</screenshot>

--- a/vdrift.desktop
+++ b/vdrift.desktop
@@ -1,11 +1,10 @@
-﻿[Desktop Entry]
-Encoding=UTF-8
+[Desktop Entry]
 Type=Application
 Name=VDrift
-Version=2012-07-22
+Version=1.0
 GenericName=Racing Simulation
 Comment=An open source driving simulation made with drift racing in mind
 Exec=vdrift
-Icon=vdrift.png
+Icon=vdrift
 Terminal=false
 Categories=Game;Simulation;


### PR DESCRIPTION
Fixed .desktop-file according to https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
* Removed BOM from .desktop
* Set correct version in .desktop (version is the version of the Desktop
  Entry Specification not of the application)
* Encoding is deprecated (always UTF-8)
* Set correct Icon name (the name should not contain an file extension)

Fixed invalid xml of appdata file
* Removed invalid xml tag (there was no opening tag) from appdata