### PR TITLE
Documentation fixes

### DIFF
--- a/docs/JOE_format.md
+++ b/docs/JOE_format.md
@@ -32,6 +32,8 @@ This block of information initiates every file.
 
 details a single configuration of a model. "File Header.num\_frames" frames follow the file header.
 
+before each frame header, you will find "File Header.num\_faces" Face blocks.
+
 | data type | block offset | name            | description                                           |
 |-----------|--------------|-----------------|-------------------------------------------------------|
 | int       | 0            | num\_verts      | the number of vertices used in this frame             |
@@ -40,7 +42,6 @@ details a single configuration of a model. "File Header.num\_frames" frames foll
 
 after each frame header, you will find
 
--   File Header.num\_faces Face blocks
 -   num\_verts Vertex blocks
 -   num\_normals Vertex blocks
 -   num\_textcoords Texture Coordinate blocks

--- a/docs/JOE_format.md
+++ b/docs/JOE_format.md
@@ -23,7 +23,7 @@ This block of information initiates every file.
 
 | data type | block offset | name        | description                                                                                                                               |
 |-----------|--------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| int       | 0            | magic       | **8441211611**(0x1F722AADB): number used to identify the file as a JOE file. Currently unchecked by vdrift.                               |
+| int       | 0            | magic       | **844121161**(0x32504449): number used to identify the file as a JOE file. Currently unchecked by vdrift.                                 |
 | int       | 4            | version     | report the file version that this file conforms to. This specification details version 3 of the format.                                   |
 | int       | 8            | num\_faces  | every frame is expected to contain the same number of faces (polygons) this value specifies how many. This is currently limited to 32000. |
 | int       | 12           | num\_frames | Presumably, this details the number of frames used in an animation. Currently constrained to "1"                                          |


### PR DESCRIPTION
This fixes some errors in the JOE format documentation.

The magic number is 0x32504449, and not 0x1F722AADB. 0x1F722AADB doesn't even fit on 32 bits.

The face blocks come before the frame header, not after. You can see in src/graphics/model_joe03.cpp that the faces are read before the 3 integers forming the frame header (https://github.com/VDrift/vdrift/blob/master/src/graphics/model_joe03.cpp#L295).