### PR TITLE
Fix linking with libusb

### DIFF
--- a/tools/G25manage/Makefile
+++ b/tools/G25manage/Makefile
@@ -1,7 +1,7 @@
 all : G25manage
 
 G25manage: G25manage.c
-	gcc -Wall -lusb -g3 -o G25manage G25manage.c
+	gcc -Wall -g3 -o G25manage G25manage.c -lusb
 
 G25manage-static: G25manage.c
 	gcc -Wall -o G25manage G25manage.c /usr/lib/libusb.a


### PR DESCRIPTION
The -l flag has to be specified after the files that depend on the library.