### PR TITLE
Fix loading controls

### DIFF
--- a/src/carcontrolmap.cpp
+++ b/src/carcontrolmap.cpp
@@ -308,9 +308,10 @@ bool CarControlMap::Load(const std::string & controlfile, std::ostream & info_ou
 		Control newctrl;
 		if (type == "joy")
 		{
-			newctrl.device = 0;
 			std::string joy_type;
-			if (!controls_config.get(i, "joy_index", newctrl.device, error_output)) continue;
+			int device = 0;
+			if (!controls_config.get(i, "joy_index", device, error_output)) continue;
+			newctrl.device = (unsigned char) device;
 			if (!controls_config.get(i, "joy_type", joy_type, error_output)) continue;
 
 			if (joy_type == "button")


### PR DESCRIPTION
Previously, the joystick index would be interpreted as a single
character, because its type is unsigned char, resulting in joystick 0
turning into joystick 48 when vdrift is restarted. Now, the config is
interpreted as a number as it should be.