### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,4 @@
-import os, sys, errno, SCons
-from time import gmtime, strftime
+import os, sys, time, errno, SCons
 
 #---------------#
 # Build Options #
@@ -395,7 +394,7 @@ else:
 #------------------------#
 # Version, debug/release #
 #------------------------#
-version = strftime("%Y-%m-%d")
+version = time.strftime("%Y-%m-%d", time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
 build_dir = 'build'
 if env['release']:
     # release build, debugging off, optimizations on


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC/gmtime to be independent of timezone.

This PR was done while working on reproducible builds for openSUSE.