### PR TITLE
build: Add an 'iconsdir' option.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -29,6 +29,7 @@ opts.Add(BoolVariable('verbose', 'Show verbose compiling output', 1))
 cppdefines = []
 default_settingsdir = ".vdrift"
 default_prefix = "/usr/local"
+default_iconsdir = "share/icons/hicolor"
 default_datadir = "share/games/vdrift/data"
 default_localedir = "share/locale"
 default_bindir = "bin"
@@ -161,8 +162,9 @@ if ARGUMENTS.get('verbose') != "1":
 #-------------------------------#
 opts.Add('settings', 'Directory under user\'s home dir where settings will be stored', default_settingsdir )
 opts.Add('prefix', 'Path prefix.', default_prefix)
-# in most case datadir doesn't exsist => do not use PathOption (Fails on build)
-opts.Add('datadir', 'Path suffix where where VDrift data will be installed', default_datadir) 
+# in most case datadir doesn't exist => do not use PathOption (Fails on build)
+opts.Add('datadir', 'Path suffix where VDrift data will be installed', default_datadir)
+opts.Add('iconsdir', 'Path suffix where VDrift icons will be installed', default_iconsdir)
 opts.Add('localedir', 'Path where VDrift locale will be installed', default_localedir)
 opts.Add('bindir', 'Path suffix where VDrift binary executable will be installed', default_bindir)
 
@@ -335,6 +337,7 @@ Type: 'scons' to compile with the default options.
       'scons destdir=$PWD/tmp' to install to $PWD/tmp staging area.
       'scons datadir=' to install data files into an alternate directory.
       'scons bindir=games/bin' to install executable into an alternate directory.
+      'scons iconsdir=share/icons/hicolor' to install the icons into an alternate directory.
       'scons localedir=/usr/share/locale' to install language files into an alternate directory.
       'scons release=1' to turn on compiler optimizations and disable debugging info.
       'scons builddir_release=build' to set release build directory.
@@ -375,6 +378,7 @@ env = conf.Finish()
 # directories #
 #-------------#
 env['data_directory'] = env['destdir'] + env['prefix'] + '/' + env['datadir']
+env['icons_directory'] = env['destdir'] + env['prefix'] + '/' + env['iconsdir']
 env['locale_directory'] = env['destdir'] + env['prefix'] + '/' + env['localedir']
 cppdefines.append(("SETTINGS_DIR", '"%s"' % env['settings']))
 if sys.platform in ['win32', 'msys', 'cygwin']:


### PR DESCRIPTION
This fixes the icon not being found for XDG systems such as GNU/Linux, partially addressing <https://github.com/VDrift/vdrift/issues/180>.

It should be applied the following patch to the vdrift-data SVN repo:
```diff
Index: vdrift-data/SConscript
===================================================================
--- vdrift-data/SConscript	(revision 1460)
+++ vdrift-data/SConscript	(working copy)
@@ -10,6 +10,7 @@
 #---------#
 src = []
 
+# Install every single file to the data directory.
 for root, dirs, files in os.walk("."):
   if root.find('.svn') == -1:
     for file in [f for f in files if not f.endswith('~')]:
@@ -40,3 +41,6 @@
     env.MoBuild(mo_file, po_file)
     install = env.InstallAs(os.path.join(env.subst('$locale_directory'), mo_tgt_file), mo_file)
     env.Alias("install", install)
+
+# Also copy the icons to a suitable location for the system.
+SConscript('textures/icons/SConscript')
Index: vdrift-data/textures/icons/SConscript
===================================================================
--- vdrift-data/textures/icons/SConscript	(revision 1460)
+++ vdrift-data/textures/icons/SConscript	(working copy)
@@ -19,5 +19,10 @@
 #--------------------#
 # Install data files #
 #--------------------#
-install = env.Install(Dir(env.subst('$data_directory/textures/icons')), src)
-env.Alias('install', install)
+# Install the icons per the Icon Theme Specification (see:
+# https://specifications.freedesktop.org/icon-theme-spec/)
+iconsdir = Dir(env.subst('$icons_directory')).abspath
+install1 = env.InstallAs(iconsdir + '/16x16/apps/vdrift.png', 'vdrift-16x16.png')
+install2 = env.InstallAs(iconsdir + '/32x32/apps/vdrift.png', 'vdrift-32x32.png')
+install3 = env.InstallAs(iconsdir + '/64x64/apps/vdrift.png', 'vdrift-64x64.png')
+env.Alias('install', [install1, install2, install3])

```
