### PR TITLE
chore: Fix SDL3 lookup

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -161,7 +161,7 @@ common_libs = ['vorbisfile', 'curl', 'z']
 if sys.platform in ['freebsd6', 'freebsd7', 'freebsd8', 'freebsd9']:
     common_libs.append('libLinearMath')
     common_libs.append('libBulletCollision')
-    local_env.ParseConfig('sdl3-config --cflags --libs')
+    local_env.ParseConfig('pkg-config sdl3 --cflags --libs')
     local_env.Append(LIBPATH = ['/usr/X11R6/lib'])
     libs_link = ['pthread', common_libs]
 elif ( 'darwin' == sys.platform ):
@@ -217,7 +217,7 @@ elif sys.platform in ['win32', 'msys', 'cygwin']:
     #local_env.Append(LIBPATH = ['/usr/lib/mingw', '#tools/win/lib', '#build'])
     libs_link = ['opengl32', 'mingw32', 'SDL3', 'intl', common_libs ]
 else:
-    local_env.ParseConfig('sdl3-config --cflags --libs')
+    local_env.ParseConfig('pkg-config sdl3 --cflags --libs')
     #local_env.Append(LIBPATH = ['/usr/X11R6/lib'])
     libs_link = ['GL','pthread', common_libs]
 


### PR DESCRIPTION
SDL3 no longer ships sdl3-config, but relies on pkgconfig